### PR TITLE
Readme Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ make docker_build
 Download or build the docker image and then set your PATH to this repo with:
 
 ```bash
-export PATH="$(pwd)/kiri-docker/"
+export PATH=$PATH:{PATH-TO-THIS-REPO}
 ```
 
 # Using Kiri Docker

--- a/README.md
+++ b/README.md
@@ -11,14 +11,7 @@ The existing kiri-docker image is hosted in Docker Hub here https://hub.docker.c
 
 # Getting the existing docker image
 
-The docker container can be donwloaded through this repo with:
-
-```bash
-gh repo clone leoheck/kiri-docker
-make docker_pull
-```
-
-Alternatively, you can pull the latest image file with:
+You can pull the latest image file with:
 ```bash
 docker pull leoheck/kiri:latest
 ```


### PR DESCRIPTION
Solves https://github.com/leoheck/kiri-docker/issues/7

The README currently specifies a command to overwrite the users PATH. Noted [here](https://github.com/leoheck/kiri-docker/issues/3#issuecomment-2047551206) as well. 

The 2nd commit you might not agree with, so let me know if you want me to remove that. I can understand from a dev point of view wanting a shorthand for it, but from a user's standpoint I think this is confusing. 

The first commit should be a given I'd think though. 