### PR TITLE
Adding workaround for git dubious owner

### DIFF
--- a/kiri-docker
+++ b/kiri-docker
@@ -171,6 +171,7 @@ main()
 			read -r -d '' KIRI_SCRIPT <<- EOM
 			    cd "${docker_repo_path}" || exit 1 ;\
 			    sudo -H Xvfb -f \${DISPLAY} -screen 0 1280x800x24 -ac -dpi 96 +extension RANDR :1 > /dev/null 2>&1 \& ;\
+                            git config --global --add safe.directory "${docker_repo_path}" ;\
 			    xvfb-run kiri -i \$(ip) ${kiri_args} ;\
 			    zsh -i
 			EOM


### PR DESCRIPTION
Workaround for https://github.com/leoheck/kiri-docker/issues/8

Ideally the container user would assume the same UID:GID of the host user, but I couldn't get this to work, and adding it the `${docker_repo_path}` was the simplest solution to overcoming the error. You may want to revisit this and apply a proper fix that doesn't do what I did, and essentially bypass the safety measures intended by git.  